### PR TITLE
Integrate Azure OpenAI route planner backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Azure OpenAI configuration
+AZURE_OPENAI_ENDPOINT=https://your-resource-name.openai.azure.com/
+AZURE_OPENAI_API_KEY=your-azure-openai-key
+AZURE_OPENAI_DEPLOYMENT=gpt-5-chat
+AZURE_OPENAI_API_VERSION=2025-01-01-preview
+
+# Optional Flask server settings
+PORT=5000

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.env
+__pycache__/
+*.pyc

--- a/index.html
+++ b/index.html
@@ -87,6 +87,7 @@
                 <a href="#solution" class="nav-link">解決方案</a>
                 <a href="#impact" class="nav-link">預期成效</a>
                 <a href="#roadmap" class="nav-link">計畫時程</a>
+                <a href="#ai-planner" class="nav-link">AI排程助理</a>
                 <a href="#team" class="nav-link">團隊與資源</a>
             </div>
             <button id="mobile-menu-button" class="md:hidden p-2">
@@ -100,6 +101,7 @@
             <a href="#solution" class="block py-2 px-6 text-sm hover:bg-gray-100">解決方案</a>
             <a href="#impact" class="block py-2 px-6 text-sm hover:bg-gray-100">預期成效</a>
             <a href="#roadmap" class="block py-2 px-6 text-sm hover:bg-gray-100">計畫時程</a>
+            <a href="#ai-planner" class="block py-2 px-6 text-sm hover:bg-gray-100">AI排程助理</a>
             <a href="#team" class="block py-2 px-6 text-sm hover:bg-gray-100">團隊與資源</a>
         </div>
     </header>
@@ -314,6 +316,34 @@
                                 </div>
                             </div>
                         </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section id="ai-planner" class="py-20">
+            <div class="container mx-auto px-6">
+                <div class="text-center mb-12">
+                    <h2 class="text-3xl font-bold mb-3">AI排程助理</h2>
+                    <p class="text-lg text-gray-600 max-w-3xl mx-auto">
+                        透過串接 Azure OpenAI，我們提供一個安全的排程小幫手，協助護理團隊快速取得符合特殊時段需求與動線效率的訪視建議。
+                    </p>
+                </div>
+                <div class="max-w-4xl mx-auto bg-white shadow-lg rounded-xl p-8 border border-accent-green/30">
+                    <form id="ai-planner-form" class="space-y-6">
+                        <div>
+                            <label for="ai-planner-input" class="block text-sm font-medium text-gray-700 mb-2">輸入個案與路線需求</label>
+                            <textarea id="ai-planner-input" rows="6" class="w-full border border-accent-green/40 rounded-lg p-4 focus:outline-none focus:ring-2 focus:ring-accent-green focus:border-transparent" placeholder="範例：\n- 日期：2025/09/26\n- 出發地：台南市政府前住民服務中心，08:00出發\n- 病人A：...\n- 特殊需求：..." required></textarea>
+                            <p class="text-xs text-gray-500 mt-2">系統會自動帶入專業角色與排程格式要求，僅需補充當天個案的特別需求與限制。</p>
+                        </div>
+                        <button type="submit" class="w-full md:w-auto px-6 py-3 bg-accent-green text-white font-semibold rounded-lg shadow hover:bg-accent-green/90 transition">生成訪視排程</button>
+                    </form>
+                    <div class="mt-8 space-y-4">
+                        <div id="ai-planner-status" class="text-sm text-gray-500"></div>
+                        <div id="ai-planner-loading" class="hidden text-center text-accent-green">
+                            <span class="animate-pulse">AI 正在規劃訪視路線...</span>
+                        </div>
+                        <pre id="ai-planner-result" class="hidden whitespace-pre-wrap bg-soft-earth rounded-lg p-4 text-sm text-gray-700 overflow-x-auto"></pre>
                     </div>
                 </div>
             </div>
@@ -536,6 +566,53 @@
                     }
                 });
             });
+
+            const plannerForm = document.getElementById('ai-planner-form');
+            if (plannerForm) {
+                const input = document.getElementById('ai-planner-input');
+                const statusEl = document.getElementById('ai-planner-status');
+                const loadingEl = document.getElementById('ai-planner-loading');
+                const resultEl = document.getElementById('ai-planner-result');
+
+                plannerForm.addEventListener('submit', async (event) => {
+                    event.preventDefault();
+                    const prompt = (input.value || '').trim();
+                    if (!prompt) {
+                        statusEl.textContent = '請先輸入至少一項訪視需求。';
+                        return;
+                    }
+
+                    statusEl.textContent = '排程規劃中...';
+                    loadingEl.classList.remove('hidden');
+                    resultEl.classList.add('hidden');
+                    resultEl.textContent = '';
+
+                    try {
+                        const response = await fetch('/api/route-plan', {
+                            method: 'POST',
+                            headers: {
+                                'Content-Type': 'application/json'
+                            },
+                            body: JSON.stringify({ prompt })
+                        });
+
+                        if (!response.ok) {
+                            const errorPayload = await response.json().catch(() => ({}));
+                            throw new Error(errorPayload.error || '伺服器發生未知錯誤');
+                        }
+
+                        const data = await response.json();
+                        const content = data.content || 'AI 未回傳任何內容，請稍後再試。';
+                        resultEl.textContent = content;
+                        resultEl.classList.remove('hidden');
+                        statusEl.textContent = '排程完成。';
+                    } catch (error) {
+                        statusEl.textContent = `排程失敗：${error.message}`;
+                    } finally {
+                        loadingEl.classList.add('hidden');
+                    }
+                });
+            }
         });
     </script>
 </body>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flask>=3.0.0
+python-dotenv>=1.0.0
+openai>=1.40.0

--- a/server.py
+++ b/server.py
@@ -1,0 +1,165 @@
+"""Flask application exposing an Azure OpenAI powered scheduling endpoint."""
+import os
+from functools import lru_cache
+from typing import Any, Dict, List
+
+from dotenv import load_dotenv
+from flask import Flask, jsonify, request
+from openai import AzureOpenAI
+
+load_dotenv()
+
+app = Flask(__name__)
+
+SYSTEM_PROMPT = (
+    "角色\n"
+    "你是一位專業的路線排程專家，可以洞察醫療端以及民眾段的需求以及人性，並熟知交通不同時段狀況以及當地文化習慣，"
+    "總是用盡全力與相關背景知識與工具來逐步推理出令人滿意的訪視路線。\n\n\n"
+    "格式\n"
+    "1. 以臺灣繁體中文來呈現“訪視時間表”、“訪視路線排程結果”以及“排程考量與貼心提醒”。\n"
+    "2. 訪視時間表必須包含這些項目：順序、地點類別、名稱/病人姓名、地址、時間。\n"
+    "3. 時間格式為24小時制，HH：MM 。\n"
+    "4. ”訪視路線排程結果“則是會在訪視時間表下方呈現一個連結按鈕（排程路線地圖），點按之後可以連結到Google地圖應用程式或是網頁，呈現訪視路線地圖。\n"
+    "5. “排程考量與貼心提醒”：簡易說明這份訪視路線排程要注意的地方。\n\n\n\n"
+    "指令\n"
+    "1. 必須遵守角色設定，還有以臺灣繁體中文來呈現方式時間表以及路線排程結果。\n"
+    "2.先置放完優先事項的時間點或是特殊訪視時段要求以及限制之後才能開始排程。\n"
+    "3. 排程前必須先調用Google Map的Function去得到任兩點的交通距離以及時間。\n"
+    "4. 依據特殊個案的優先指定時段還有得到的任兩點交通距離時間再來遵守「拓撲排序」邏輯來編排訪視路線。\n"
+    "5.訪視後的路線必須完成特殊個案的優先指定時段以及最佳經濟效率的路線排班。\n"
+    "6. 排完路線後，需要呈現完整詳細的訪視時間表以及在Google 地圖上畫出訪視路線地圖。\n"
+    "7. 訪視時間表必須包含這些項目：順序、地點類別、名稱/病人姓名、地址、時間。\n"
+    "8. 順序：保留項目名稱為阿拉伯數字，出發點為0。\n"
+    "9. 地點類別：保留項目名稱，項目包含：出發點、病人、用餐、終點。\n"
+    "10.名稱/病人姓名：保留項目名稱，項目包含：起點名稱、病人姓名（+特殊時段需求/極簡背景備註）、終點名稱\n"
+    "11. 地址：保留項目名稱，寫出對應的地址資訊，用餐地址空白即可。\n"
+    "12. 時間：保留項目名稱，項目包含起點出發時間（出發點）、抵達時間（病人）、訪視停留時間（病人）、離開時間（彬病人）、用餐時間（移動緩衝時間）、抵達時間（終點）。時間格式為24小時制，HH：MM 。\n"
+    "13. ”訪視路線排程結果“則是會在訪視時間表下方呈現一個連結按鈕（排程路線地圖），點按之後可以連結到Google地圖應用程式或是網頁，呈現訪視路線地圖。\n"
+    "14. “排程考量與貼心提醒”：在”訪視路線排程結果“之後，簡易說明這份訪視路線排程要注意的地方，禁止說到拓撲兩個字，只需要說名是否有符合特殊時段需求以及最佳路線排程即可。\n"
+    "15. 病人訪視一定要嚴格遵守「拓撲排序」邏輯。"
+)
+
+
+class ConfigurationError(RuntimeError):
+    """Raised when mandatory Azure OpenAI configuration is missing."""
+
+
+@lru_cache(maxsize=1)
+def build_client() -> Dict[str, Any]:
+    """Create a cached Azure OpenAI client and return it with deployment info."""
+    endpoint = os.getenv("AZURE_OPENAI_ENDPOINT") or os.getenv("ENDPOINT_URL")
+    deployment = os.getenv("AZURE_OPENAI_DEPLOYMENT") or os.getenv("DEPLOYMENT_NAME")
+    api_key = os.getenv("AZURE_OPENAI_API_KEY")
+    api_version = os.getenv("AZURE_OPENAI_API_VERSION", "2025-01-01-preview")
+
+    if not endpoint or not deployment or not api_key:
+        raise ConfigurationError(
+            "Azure OpenAI 設定不完整，請確認 AZURE_OPENAI_ENDPOINT、AZURE_OPENAI_DEPLOYMENT 以及 AZURE_OPENAI_API_KEY 已設定於環境變數或 .env。"
+        )
+
+    client = AzureOpenAI(
+        azure_endpoint=endpoint,
+        api_key=api_key,
+        api_version=api_version,
+    )
+    return {"client": client, "deployment": deployment}
+
+
+def _normalize_messages(user_messages: List[Dict[str, Any]], prompt: str) -> List[Dict[str, Any]]:
+    messages: List[Dict[str, Any]] = [
+        {
+            "role": "system",
+            "content": [
+                {
+                    "type": "text",
+                    "text": SYSTEM_PROMPT,
+                }
+            ],
+        }
+    ]
+
+    for message in user_messages:
+        role = message.get("role")
+        content = message.get("content")
+        if not role or content is None:
+            continue
+        if isinstance(content, str):
+            content_payload = [{"type": "text", "text": content}]
+        elif isinstance(content, list):
+            content_payload = content
+        else:
+            continue
+        messages.append({"role": role, "content": content_payload})
+
+    if prompt:
+        messages.append(
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": prompt,
+                    }
+                ],
+            }
+        )
+
+    return messages
+
+
+@app.post("/api/route-plan")
+def generate_route_plan():
+    payload = request.get_json(silent=True) or {}
+    prompt = (payload.get("prompt") or payload.get("user_prompt") or "").strip()
+    user_messages = payload.get("messages") or []
+
+    if not prompt and not user_messages:
+        return (
+            jsonify({"error": "請提供至少一段訪視需求說明或歷史對話。"}),
+            400,
+        )
+
+    messages = _normalize_messages(user_messages if isinstance(user_messages, list) else [], prompt)
+
+    try:
+        config = build_client()
+        completion = config["client"].chat.completions.create(
+            model=config["deployment"],
+            messages=messages,
+            max_completion_tokens=payload.get("max_completion_tokens", 4096),
+            temperature=payload.get("temperature", 0.2),
+        )
+    except ConfigurationError as config_error:
+        return jsonify({"error": str(config_error)}), 500
+    except Exception as exc:  # pragma: no cover - network errors
+        return (
+            jsonify({"error": "Azure OpenAI 服務呼叫失敗", "detail": str(exc)}),
+            502,
+        )
+
+    choice = completion.choices[0] if completion.choices else None
+    message_content = ""
+    if choice and choice.message:
+        message_content = choice.message.content or ""
+
+    response_payload: Dict[str, Any] = {
+        "content": message_content,
+        "usage": getattr(completion, "usage", None),
+    }
+
+    if choice and getattr(choice, "finish_reason", None):
+        response_payload["finish_reason"] = choice.finish_reason
+
+    if choice and getattr(choice, "message", None):
+        response_payload["message_role"] = choice.message.role
+
+    return jsonify(response_payload)
+
+
+@app.get("/health")
+def health_check():
+    return jsonify({"status": "ok"})
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app.run(host="0.0.0.0", port=int(os.getenv("PORT", "5000")))


### PR DESCRIPTION
## Summary
- add a Flask-based API that proxies route-planning prompts to Azure OpenAI using environment variables
- provide environment variable template, dependency list, and gitignore entries for local secrets
- extend the SPA with an AI排程助理 section that submits requests to the new backend

## Testing
- python -m compileall -f server.py

------
https://chatgpt.com/codex/tasks/task_e_68d5908e04e08326b6814812e245c282